### PR TITLE
Custom AppDynamics Metrics support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   </parent>
 
   <artifactId>appdynamics-dashboard</artifactId>
-  <version>1.0.8-SNAPSHOT</version>
+  <version>1.0.9-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>AppDynamics Dashboard Plugin for Jenkins</name>

--- a/src/main/java/nl/codecentric/jenkins/appd/BuildActionResultsDisplay.java
+++ b/src/main/java/nl/codecentric/jenkins/appd/BuildActionResultsDisplay.java
@@ -17,6 +17,7 @@ import org.kohsuke.stapler.StaplerResponse;
 
 import java.awt.*;
 import java.io.IOException;
+import java.net.URLEncoder;
 
 /**
  * Root object of a AppDynamics Build Report.
@@ -56,6 +57,17 @@ public class BuildActionResultsDisplay implements ModelObject {
 
   public AppDynamicsReport getAppDynamicsReport() {
     return currentReport;
+  }
+
+  public String getEncodedString(String str) {
+    String encodedStr;
+    try {
+      encodedStr = URLEncoder.encode(str, "UTF8");
+    }
+    catch (Exception e) {
+      return "";
+    }
+    return encodedStr;
   }
 
   private void addPreviousBuildReportToExistingReport() {

--- a/src/main/resources/nl/codecentric/jenkins/appd/AppDynamicsResultsPublisher/config.jelly
+++ b/src/main/resources/nl/codecentric/jenkins/appd/AppDynamicsResultsPublisher/config.jelly
@@ -27,6 +27,9 @@
       <f:entry field="thresholdMetric" title="${%appdynamics.threshold.metric.title}"
                description="${%appdynamics.threshold.metric.description}">
         <f:select/>
+      <f:entry title="${%appdynamics.threshold.customMetricPath.title}" description="${%appdynamics.threshold.customMetricPath.description}">
+          <f:textbox field="customMetricPath" default="${descriptor.defaultCustomMetricPath}"/>
+        </f:entry>
       </f:entry>
       <f:entry title="${%appdynamics.threshold.lower.title}">
         <f:checkbox field="lowerIsBetter" default="true"/>

--- a/src/main/resources/nl/codecentric/jenkins/appd/AppDynamicsResultsPublisher/config.properties
+++ b/src/main/resources/nl/codecentric/jenkins/appd/AppDynamicsResultsPublisher/config.properties
@@ -18,6 +18,8 @@ appdynamics.connection.test.progress=Testing...
 
 appdynamics.threshold.metric.title=Threshold Metric
 appdynamics.threshold.metric.description=AppDynamics Metric that will be used to decide if thresholds are reached
+appdynamics.threshold.customMetricPath.title=Custom Metric Path
+appdynamics.threshold.customMetricPath.description=Custom Metric Path from AppDynamics Metric Browser
 appdynamics.threshold.lower.title=Lower is better
 appdynamics.minmeasuretime.title=Minimum Measure Time
 appdynamics.minmeasuretime.description=Minimum time-span in minutes for which statistics are fetched (default 10 min)

--- a/src/main/resources/nl/codecentric/jenkins/appd/BuildActionResultsDisplay/index.jelly
+++ b/src/main/resources/nl/codecentric/jenkins/appd/BuildActionResultsDisplay/index.jelly
@@ -24,7 +24,7 @@
 
             </td>
             <td width="50%">
-              <img class="trend" src="./summarizerGraph?width=600&amp;height=440&amp;metricDataKey=${metricData.metricPath}" width="600" height="440" />
+              <img class="trend" src="./summarizerGraph?width=600&amp;height=440&amp;metricDataKey=${it.getEncodedString(metricData.metricPath)}" width="600" height="440" />
             </td>
           </tr>
         </table>


### PR DESCRIPTION
Hi Miel!

I've integrated AppDynamics plugin into the Jenkins project and faced with an issue that I have to receive some custom metrics data from AppDynamics. 
Like "Application Infrastructure Performance|MyProj|Hardware Resources|CPU|%Busy" 

But current implementation doesn't support this case.

So Custom Metrics support has been added and now we are able to specify AppDynamics metric just in plugin's settings, like:

![custom metrics](https://cloud.githubusercontent.com/assets/8005242/8045835/f9d52b18-0e3e-11e5-9307-99cb00a4fb7e.jpg)

Please review.

Thanks, 
Volodymyr

